### PR TITLE
Added/fixed specs of connectors that are being used, some additional minor changes

### DIFF
--- a/bed/index.md
+++ b/bed/index.md
@@ -2,8 +2,8 @@
 
 Well, not the heating bed itself, which seems quite standard, but the sensors there.
 
-# The "enhanced levi-Q 2.0"
-I've done some measurings and is simply a very sensitive switch. We can probably treat it as a Z-limit switch after putting the head in the right position.
+# The "enhanced LeviQ 2.0"
+I've done some measurings and the z-offset sensor simply is a very sensitive switch. We can probably treat it as a Z-limit switch after putting the head in the right position.
 The pad next to it is a silicone pad to clean the head before testing the switch.
 
 ![A view of the Levi-Q system from above](components-above.png)
@@ -11,9 +11,9 @@ The pad next to it is a silicone pad to clean the head before testing the switch
 # Pinout
 ![A view of the heating bed from below](components-below.png)
 As the pinout is quite straightforward, I won't do the fancy SVG.
-* Bed and T1 are soldered directly to the board
-* Z-limit goes to CALIBRATION in motherboard. JST-ZHR2
-* ACC-SENSOR goes to the connector of the same name in motherboard. JST-ZHR7
+* Bed and T1 are soldered directly to the board.
+* Z-limit goes to CALIBRATION in motherboard. Connector: 2pin JST PH 2.0 type.
+* ACC-SENSOR goes to the connector of the same name in motherboard. Connector: 7pin JST PH 2.0 type.
 
 # The accelerometer
 ![The accelerometer board, taken with my microscope](acceleration-board.png)

--- a/motherboard/index.md
+++ b/motherboard/index.md
@@ -11,7 +11,7 @@ The motherboard doesn't feature any SD card reader, but includes 8GB of flash me
 
 For driving the axis, the motherboard has four TMC2209 stepper drivers soldered directly. It communicates with them via UART.
 
-And fortunately for us, it has a soldered Debug header with clearly labeled pinout so we can work our way out of this mess.
+And fortunately for us, it has a soldered debug header with clearly labeled pinout so we can work our way out of this mess.
 
 ![Photo of the motherboard, with some of the components labeled](./motherboard-reference.png)
 ### Some more notes
@@ -23,13 +23,13 @@ And fortunately for us, it has a soldered Debug header with clearly labeled pino
 ![Pinout of the motherboard](motherboard-pinout.svg)
 
 Connectors are as follows
-* POWER and HOTBED use straight power cables (tipped)
-* MB-FAN, T1, and LIGHT use PHR-2
-* CALIBRATION uses a JST ZHR2
-* ACC-SENSOR uses a JST ZHR7
-* ZL and ZR use JST PHR-4
-* Y-CON uses JST PHR-7
-* X-CON and E-CON use (I think) JVT "PHB" connectors (JVT2041HNO-14 and JVT2041HNO-24 respectively)
+* POWER and HOTBED use straight power cables with ferrules being added
+* MB-FAN, T1, and LIGHT use 2pin XH 2.54
+* CALIBRATION uses a 2pin JST PH 2.0
+* ACC-SENSOR uses a 7pin JST PH 2.0
+* ZL and ZR use 4pin JST XH 2.54
+* Y-CON uses 7pin JST XH 2.54
+* X-CON (14pin) and E-CON (24pin) use JVT PHB 2.0 connectors (JVT2041HNO-14 and JVT2041HNO-24 respectively)
 
 
 ## Other relevant data

--- a/printhead/index.md
+++ b/printhead/index.md
@@ -1,25 +1,27 @@
 # The printhead
 
-(If you want nice photos of the printhead, [Kobra pro 2 insights prinhead page](https://1coderookie.github.io/Kobra2ProInsights/hardware/printhead/) has a lot!)
+(If you want nice photos of the printhead, [Kobra 2 Pro Insights printhead page](https://1coderookie.github.io/Kobra2ProInsights/hardware/printhead/) has a lot!)
 
 The new printhead is used in the Kobra 2 Pro, Plus and Max, and contains the following inside:
 * A 6-wire stepper (center taps not connected to motherboard). Model is marked as **42SHDB0066Z-10WD** connected to a direct drive system.
 * A 100k NTC Thermistor.
 * A 24V 60W heater cartridge
-* An anycubic custom heater block. Is styled as a volcano, but is not compatible. There's a 40mm PTFE tube for the heatbreak, and comes with a silicone sock.
+* A proprietary Anycubic Volcano-style heater block, comes with a silicone sock.  
+* A proprietary Anycubic Volcano-style nozzle, incompatible with a regular heatbreak. The cylindric shaped end of the nozzle fits inside the bottom end of the heatbreak's throat. 
+* A heatbreak (total length 26mm, 6mm OD / 4mm ID throat, M6 thread) with a ~40mm PTFE tube.
 * The heatsink fan is a 24V 30x30x10 axial fan. Model marked as **HSC BCY3010D24H**
 * The part cooling fan is a 24V 50x50x20 centrifugal fan. Model is marked as **COOLCOX BF5020H24D**
-* An induction sensor for automatic bed leveling. According to 1coderookie, is a PNP-NO type, similar if not the same as the ones used in previous Kobra models.
-* A distribution board that also contains an accelerometer. Is the same accelerometer that the bed uses and judging from the pinout seems to be a LIS2DW12.
+* An inductive proximity sensor for "Automatic Bed Leveling". According to [1coderookie](https://github.com/1coderookie), it is a PNP-NO type, 6-36V operating voltage.  
+* A distribution board that also contains an accelerometer. It is the same type of accelerometer that is being used at the bed, an LIS2DW12.
 
 ## Pinouts
 ![Printhead pinout](Printhead-pinout.svg)
 
 Connectors are as follows:
-* Motherboard is a 2 row x 9 pin molex, 2,54mm spacing.
-* T0, FAN0 and FAN1 are JST PH connectors, 2 pins.
-* LEVE is a JST PH connector, 3 pins.
-* HEATER is a Molex Micro-Fit connector, 2 pins.
+* Motherboard is a 2 row x 9 pin IDC connector.
+* T0, FAN0 and FAN1 are JST PH 2.0 connectors, 2 pins.
+* LEVE is a JST PH 2.0 connector, 3 pins.
+* HEATER is a Molex Micro-Fit 3.0 connector, 2 pins.
 
 ## Extra images
 ![The distribution board](./printhead_distributor.png)

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 _**Note:** this probably is also applicable to Kobra 2 Plus and Max, as they seem to use the same motherboard and printhead, but I do not own one of these, so I cannot confirm_
 
-The purpose of this repository is sharing my efforts to make the new Kobra 2 machines usable. Suffice to say, I'm very dissatisfied with Anycubic's decision to block serial input and force us to print through their servers - and accepting terms that include giving anycubic the rights to reproduce anything we upload to our printers, and the right of anycubic to disconnect our printer if they feel we are doing **illegal things**, without very much specifics about what they consider illegal.
+The purpose of this repository is sharing my efforts to make the new Kobra 2 Pro machines usable. Suffice to say, I'm very dissatisfied with Anycubic's decision to block serial input and force us to print through their servers - and accepting terms that include giving anycubic the rights to reproduce anything we upload to our printers, and the right of anycubic to disconnect our printer if they feel we are doing **illegal things**, without very much specifics about what they consider illegal.
 
 Anyway, I could rant over how they have not published the source code, which probably is a violation of the GPL, as a cursory examination of the files show klipper headers over there, or how I feel about them ommitting the fact that we no longer have direct control on our printer.
 
@@ -16,7 +16,7 @@ Instead of that, let's just go over what I found so far.
 ## Other noteworthy efforst I've saw, and references:
 * The thread that started it all: [Printer.cfg for Anycubic Kobra 2 Plus/Pro/Max](https://klipper.discourse.group/t/printer-cfg-for-anycubic-kobra-2-plus-pro-max/)
 * Referenced on the thread, user _kenguru_ has released a modification that allows you to redirect the MQTT messages to a server of your own, bypassing the need of using the anycubic app. [Kobra unleashed](https://github.com/anjomro/kobra-unleashed)
-* User _Catnippr_ is compiling information about the anycubic Kobra 2 Pro on its [Kobra2Pro Insights Page](https://1coderookie.github.io/Kobra2ProInsights/)
+* User [1coderookie](https://github.com/1coderookie) is compiling information about the Anycubic Kobra 2 Pro on his [Kobra2Pro Insights Page](https://1coderookie.github.io/Kobra2ProInsights/)
 * Anycubic Reddit community has published a [FAQ for Kobra 2 Series](https://www.reddit.com/r/anycubic/comments/19113t3/faq_for_kobra_2_series/) that summarizes many of the main points of the conversation.
 
 


### PR DESCRIPTION
Hi, 
I finished swapping in a different mainboard (MKS Robin Nano v3.1) for being able to run a native Klipper (see [MOD: Different Mainboard](https://1coderookie.github.io/Kobra2ProInsights/hardware/mainboard/#mod-different-mainboard) and [MOD: MKS Robin Nano v3.1](https://1coderookie.github.io/Kobra2ProInsights/hardware/mainboard/#mod-mks-robin-nano-v31)) on my K2 Pro.  
The majority of the changes I made in your texts is about the specific types of connectors that are being used at the stock mainboard and the other components.  
In addition, I made some minor changes about certain descriptions of the head's parts, about naming, fixed some typos etc.  
Hope you'll like it - if not, just close this PR.. ;)
Greetings